### PR TITLE
feat: 日報編集・削除機能および一覧画面の編集リンク追加

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/Backend/app/crud.py
+++ b/Backend/app/crud.py
@@ -65,3 +65,17 @@ def update_user_name(db: Session, user_id: str, name: str):
     db.commit()
     db.refresh(db_user)
     return db_user    
+
+# note :編集画面でレポート削除するCRUD
+def delete_daily_report(db: Session, report_id: int, owner_id: str):
+    db_report = db.query(models.DailyReport).filter(
+        models.DailyReport.id == report_id,
+        models.DailyReport.owner_id == owner_id
+    ).first()
+
+    if db_report is None:
+        return None
+
+    db.delete(db_report)
+    db.commit()
+    return db_report

--- a/Backend/app/routers/daily_reports.py
+++ b/Backend/app/routers/daily_reports.py
@@ -64,4 +64,25 @@ def update_report(
 
     return db_report
 
+@router.delete("/{report_id}", response_model=schemas.DailyReport)
+def delete_report(
+    report_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    """
+    ログインユーザーが指定した日報を削除するエンドポイント
+    """
+    db_report = crud.delete_daily_report(
+        db=db, report_id=report_id, owner_id=current_user.id
+    )
+
+    if db_report is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="日報が見つかりません"
+        )
+
+    return db_report
+
+
 

--- a/Backend/app/routers/daily_reports.py
+++ b/Backend/app/routers/daily_reports.py
@@ -31,6 +31,19 @@ def read_reports(
     """
     return crud.get_daily_reports(db, owner_id=current_user.id)
 
+@router.get("/{report_id}", response_model=schemas.DailyReport)
+def read_report(
+    report_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(auth.get_current_user),
+):
+    """
+    ログインしているユーザーが指定した日報を1件取得するためのAPIエンドポイント
+    """
+    db_report = crud.get_daily_report(db, report_id=report_id, owner_id=current_user.id)
+    if db_report is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="日報が見つかりません")
+    return db_report
 
 @router.put("/{report_id}", response_model=schemas.DailyReport)
 def update_report(

--- a/Frontend/.eslintrc.json
+++ b/Frontend/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"]
+  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"],
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true
+      }
+    ]
+  }
 }

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -186,6 +186,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
       "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.18",
         "@firebase/logger": "0.4.4",
@@ -252,6 +253,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
       "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.2",
         "@firebase/component": "0.6.18",
@@ -267,7 +269,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.5.28",
@@ -718,6 +721,7 @@
       "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1161,6 +1165,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1592,6 +1597,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2472,6 +2478,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2555,6 +2562,7 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2656,6 +2664,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4702,6 +4711,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4797,6 +4807,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4809,6 +4820,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5551,6 +5563,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5713,6 +5726,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/Frontend/src/app/reports/[id]/edit/page.tsx
+++ b/Frontend/src/app/reports/[id]/edit/page.tsx
@@ -1,40 +1,262 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import { fetchReportById } from '@/lib/api/report';
+import { useParams, useRouter } from 'next/navigation';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '@/lib/firebase';
+
+type Report = {
+  id: number;
+  report_date: string;
+  learned_today: string;
+  learning_improvement: string;
+  challenge_for_tomorrow: string;
+  impressions: string;
+  other_notes?: string;
+};
 
 export default function EditReportPage() {
-  const { id } = useParams(); // URLの[id]を取得
-  const [report, setReport] = useState<any>(null);
+  const { id } = useParams();
+  const [user, loadingAuth] = useAuthState(auth);
+  const [report, setReport] = useState<Report | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
   useEffect(() => {
-    const getReport = async () => {
-      try {
-        console.log('取得したid:', id);
+    if (!user || loadingAuth) return;
 
-        if (typeof id === 'string') {
-          const data = await fetchReportById(id);
-          setReport(data);
-        }
-      } catch (error) {
-        console.error('レポート取得エラー:', error);
-        alert('レポートの取得に失敗しました');
+    const fetchReport = async () => {
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(`${API_URL}/daily-reports/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (!res.ok) throw new Error('レポート取得に失敗しました');
+
+        const data = await res.json();
+        setReport(data);
+      } catch (err) {
+        setError((err as Error).message);
       } finally {
         setLoading(false);
       }
     };
 
-    getReport();
-  }, [id]);
+    fetchReport();
+  }, [id, user, loadingAuth, API_URL]);
 
-  if (loading) return <p>読み込み中...</p>;
+  if (loadingAuth || loading) return <p>読み込み中...</p>;
+  if (error) return <p style={{ color: 'red' }}>{error}</p>;
 
   return (
-    <div>
-      <h1>レポート編集ページ</h1>
-      <pre>{JSON.stringify(report, null, 2)}</pre>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '1rem',
+        background: 'linear-gradient(to bottom right, #f3f4f6, #e5e7eb)', // 背景統一
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: '768px',
+          backgroundColor: '#fff',
+          padding: '2rem',
+          borderRadius: '1rem',
+          boxShadow: '0 10px 25px rgba(0,0,0,0.1)', // 新規作成と同じカード風
+        }}
+      >
+        <h1
+          style={{
+            fontSize: '2rem',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            color: '#2563eb',
+            marginBottom: '1.5rem',
+          }}
+        >
+          レポート編集ページ
+        </h1>
+
+        {report && (
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              try {
+                const token = await user?.getIdToken();
+                const res = await fetch(`${API_URL}/daily-reports/${id}`, {
+                  method: 'PUT',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                  },
+                  body: JSON.stringify(report),
+                });
+
+                if (!res.ok) throw new Error('更新に失敗しました');
+                alert('更新しました！');
+                router.push('/reports');
+              } catch (err) {
+                alert((err as Error).message);
+              }
+            }}
+            style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
+          >
+            <label>
+              日付:
+              <input
+                type="date"
+                value={report.report_date.split('T')[0]}
+                onChange={(e) =>
+                  setReport({ ...report, report_date: e.target.value })
+                }
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  border: '1px solid #ccc',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <label>
+              今日学んだこと:
+              <textarea
+                value={report.learned_today}
+                onChange={(e) =>
+                  setReport({ ...report, learned_today: e.target.value })
+                }
+                rows={3}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <label>
+              改善点:
+              <textarea
+                value={report.learning_improvement}
+                onChange={(e) =>
+                  setReport({ ...report, learning_improvement: e.target.value })
+                }
+                rows={3}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <label>
+              明日の課題:
+              <textarea
+                value={report.challenge_for_tomorrow}
+                onChange={(e) =>
+                  setReport({
+                    ...report,
+                    challenge_for_tomorrow: e.target.value,
+                  })
+                }
+                rows={3}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <label>
+              感想:
+              <textarea
+                value={report.impressions}
+                onChange={(e) =>
+                  setReport({ ...report, impressions: e.target.value })
+                }
+                rows={3}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <label>
+              その他メモ:
+              <textarea
+                value={report.other_notes || ''}
+                onChange={(e) =>
+                  setReport({ ...report, other_notes: e.target.value })
+                }
+                rows={2}
+                style={{
+                  width: '100%',
+                  padding: '0.5rem',
+                  borderRadius: '0.5rem',
+                }}
+              />
+            </label>
+
+            <button
+              type="submit"
+              style={{
+                backgroundColor: '#2563eb',
+                color: '#fff',
+                padding: '0.75rem',
+                border: 'none',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                fontSize: '1rem',
+                fontWeight: 'bold',
+              }}
+            >
+              更新する
+            </button>
+
+            <button
+              type="button"
+              style={{
+                backgroundColor: '#dc2626', // 赤系
+                color: '#fff',
+                padding: '0.75rem',
+                border: 'none',
+                borderRadius: '0.5rem',
+                cursor: 'pointer',
+                fontSize: '1rem',
+                fontWeight: 'bold',
+              }}
+              onClick={async () => {
+                if (!confirm('本当に削除しますか？')) return;
+                try {
+                  const token = await user?.getIdToken();
+                  const res = await fetch(`${API_URL}/daily-reports/${id}`, {
+                    method: 'DELETE',
+                    headers: { Authorization: `Bearer ${token}` },
+                  });
+                  if (!res.ok) throw new Error('削除に失敗しました');
+                  alert('削除しました');
+                  router.push('/reports');
+                } catch (err) {
+                  alert((err as Error).message);
+                }
+              }}
+            >
+              削除する
+            </button>
+          </form>
+        )}
+      </div>
     </div>
   );
 }

--- a/Frontend/src/app/reports/page.tsx
+++ b/Frontend/src/app/reports/page.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { useAuthState } from "react-firebase-hooks/auth";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
-import { auth } from "@/lib/firebase"; //Firebase の初期化コード
-import { ROUTES } from "@/lib/routes"; //新規と編集ページの定義
+import { auth } from '@/lib/firebase'; //Firebase の初期化コード
+import { ROUTES } from '@/lib/routes'; //新規と編集ページの定義
 
 type Report = {
   id: number;
@@ -23,7 +23,7 @@ export default function ReportsPage() {
 
   useEffect(() => {
     if (!loadingAuth && !user) {
-      router.push("/");
+      router.push('/');
       return;
     }
   }, [user, loadingAuth, router]);
@@ -40,12 +40,12 @@ export default function ReportsPage() {
           },
         });
 
-        if (!res.ok) throw new Error("データ取得に失敗しました");
+        if (!res.ok) throw new Error('データ取得に失敗しました');
 
         const data = await res.json();
         setReports(data);
       } catch (error) {
-        console.error("取得エラー:", error); // エラーログ
+        console.error('取得エラー:', error); // エラーログ
         setError(error as Error);
       } finally {
         setLoading(false);
@@ -66,31 +66,31 @@ export default function ReportsPage() {
   return (
     <div
       style={{
-        minHeight: "100vh",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        padding: "1rem",
-        background: "linear-gradient(to bottom right, #f3f4f6, #e5e7eb)",
+        minHeight: '100vh',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '1rem',
+        background: 'linear-gradient(to bottom right, #f3f4f6, #e5e7eb)',
       }}
     >
       <div
         style={{
-          width: "100%",
-          maxWidth: "768px",
-          backgroundColor: "#fff",
-          padding: "2rem",
-          borderRadius: "1rem",
-          boxShadow: "0 10px 25px rgba(0,0,0,0.1)",
+          width: '100%',
+          maxWidth: '768px',
+          backgroundColor: '#fff',
+          padding: '2rem',
+          borderRadius: '1rem',
+          boxShadow: '0 10px 25px rgba(0,0,0,0.1)',
         }}
       >
         <h1
           style={{
-            fontSize: "2rem",
-            fontWeight: "bold",
-            textAlign: "center",
-            color: "#2563eb",
-            marginBottom: "1.5rem",
+            fontSize: '2rem',
+            fontWeight: 'bold',
+            textAlign: 'center',
+            color: '#2563eb',
+            marginBottom: '1.5rem',
           }}
         >
           Daily Report
@@ -99,9 +99,9 @@ export default function ReportsPage() {
         {error && (
           <p
             style={{
-              color: "#e28080ff",
-              marginBottom: "1rem",
-              textAlign: "center",
+              color: '#e28080ff',
+              marginBottom: '1rem',
+              textAlign: 'center',
             }}
           >
             {error.message}
@@ -109,9 +109,9 @@ export default function ReportsPage() {
         )}
         <div
           style={{
-            display: "flex",
-            justifyContent: "center",
-            marginBottom: "1.5rem",
+            display: 'flex',
+            justifyContent: 'center',
+            marginBottom: '1.5rem',
           }}
         >
           <Link href={ROUTES.REPORT_NEW}>
@@ -119,19 +119,19 @@ export default function ReportsPage() {
               style={{
                 width: 220,
                 height: 50,
-                fontSize: "1.2rem",
-                backgroundColor: "#6e6b6bff",
-                color: "#ffffff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: "pointer",
-                transition: "background-color 0.3s",
+                fontSize: '1.2rem',
+                backgroundColor: '#6e6b6bff',
+                color: '#ffffff',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                transition: 'background-color 0.3s',
               }}
               onMouseOver={(e) =>
-                (e.currentTarget.style.backgroundColor = "#7a7878ff")
+                (e.currentTarget.style.backgroundColor = '#7a7878ff')
               }
               onMouseOut={(e) =>
-                (e.currentTarget.style.backgroundColor = "#4a4949ff")
+                (e.currentTarget.style.backgroundColor = '#4a4949ff')
               }
             >
               ＋ 新規作成
@@ -140,70 +140,70 @@ export default function ReportsPage() {
         </div>
 
         {reports.length === 0 ? (
-          <p style={{ textAlign: "center", color: "#6b7280" }}>
+          <p style={{ textAlign: 'center', color: '#6b7280' }}>
             まだレポートがありません。
           </p>
         ) : (
           <ul
             style={{
-              listStyle: "none",
+              listStyle: 'none',
               padding: 0,
               margin: 0,
-              gap: "1rem",
-              display: "flex",
-              flexDirection: "column",
+              gap: '1rem',
+              display: 'flex',
+              flexDirection: 'column',
             }}
           >
             {reports.map((report) => (
               <li
                 key={report.id}
                 style={{
-                  padding: "1rem",
-                  border: "1px solid #e5e7eb",
-                  borderRadius: "1rem",
-                  backgroundColor: "#f9fafb",
-                  transition: "box-shadow 0.3s",
-                  cursor: "default",
+                  padding: '1rem',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: '1rem',
+                  backgroundColor: '#f9fafb',
+                  transition: 'box-shadow 0.3s',
+                  cursor: 'default',
                 }}
                 onMouseOver={(e) =>
                   (e.currentTarget.style.boxShadow =
-                    "0 5px 15px rgba(0,0,0,0.1)")
+                    '0 5px 15px rgba(0,0,0,0.1)')
                 }
-                onMouseOut={(e) => (e.currentTarget.style.boxShadow = "none")}
+                onMouseOut={(e) => (e.currentTarget.style.boxShadow = 'none')}
               >
                 <div
                   style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                    marginBottom: "0.5rem",
+                    display: 'flex',
+                    justifyContent: 'space-between', // ← 日付左・編集右
+                    alignItems: 'center',
+                    marginBottom: '0.5rem',
                   }}
                 >
-                  {/* <span style={{ fontWeight: "500", color: "#374151" }}>
-                    {new Date(report.report_date).toLocaleDateString("ja-JP", {
-                      year: "numeric",
-                      month: "2-digit",
-                      day: "2-digit",
+                  {/* 日付表示 */}
+                  <span
+                    style={{
+                      fontWeight: '500',
+                      color: '#6b7280',
+                    }}
+                  >
+                    {new Date(report.report_date).toLocaleDateString('ja-JP', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
                     })}
-                  </span> */}
-                  <Link href={ROUTES.REPORT_EDIT(report.id)}>
-                    <span
-                      style={{
-                        fontWeight: "500",
-                        color: "#6b7280",
-                        textDecoration: "underline",
-                        cursor: "pointer",
-                      }}
-                    >
-                      {new Date(report.report_date).toLocaleDateString(
-                        "ja-JP",
-                        {
-                          year: "numeric",
-                          month: "2-digit",
-                          day: "2-digit",
-                        }
-                      )}
-                    </span>
+                  </span>
+
+                  {/* 編集リンク */}
+                  <Link
+                    href={`/${report.id}/edit`}
+                    style={{
+                      fontWeight: '500',
+                      color: '#2563eb',
+                      textDecoration: 'underline',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    編集
                   </Link>
                 </div>
               </li>

--- a/Frontend/src/app/reports/page.tsx
+++ b/Frontend/src/app/reports/page.tsx
@@ -195,7 +195,7 @@ export default function ReportsPage() {
 
                   {/* 編集リンク */}
                   <Link
-                    href={`/${report.id}/edit`}
+                    href={`/reports/${report.id}/edit`}
                     style={{
                       fontWeight: '500',
                       color: '#2563eb',

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,14 +5,11 @@ services:
     restart: always
     env_file:
       - ./Backend/.env
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "5434:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
 
 volumes:
   postgres-data:
+


### PR DESCRIPTION
## 概要
日報編集・削除機能の実装、および一覧画面から編集ページへの遷移リンクを追加しました。

## 主な変更点
- `daily_reports.py`：単体取得・削除エンドポイントを追加
- `crud.py`：日報削除処理を実装
- `EditReportPage`：削除ボタンを追加し、UIを新規作成ページと統一
- `reports/page.tsx`：日報一覧に編集リンクを追加

## 動作確認
- 日報の新規作成・編集・削除が正常に動作することを確認
- 未ログイン時は `/` へリダイレクトされることを確認
