### PR TITLE
fix(ui): レポート一覧ページで日付を表示し、横に編集リンクを配置

### DIFF
--- a/Frontend/src/app/reports/page.tsx
+++ b/Frontend/src/app/reports/page.tsx
@@ -136,10 +136,7 @@ export default function ReportsPage() {
         </div>
 
         {reports.length === 0 ? (
-
-          <p style={{ textAlign: 'center', color: '#6b7280' }}>
-            まだレポートがありません。
-          </p>
+          <p style={{ textAlign: 'center', color: '#6b7280' }}>まだレポートがありません。</p>
         ) : (
           <ul
             style={{
@@ -164,17 +161,13 @@ export default function ReportsPage() {
                 }}
                 onMouseOver={(e) =>
                   (e.currentTarget.style.boxShadow = '0 5px 15px rgba(0,0,0,0.1)')
-                  (e.currentTarget.style.boxShadow =
-                    '0 5px 15px rgba(0,0,0,0.1)')
-
                 }
                 onMouseOut={(e) => (e.currentTarget.style.boxShadow = 'none')}
               >
                 <div
                   style={{
                     display: 'flex',
-
-                    justifyContent: 'space-between', 
+                    justifyContent: 'space-between',
                     alignItems: 'center',
                     marginBottom: '0.5rem',
                   }}
@@ -191,22 +184,6 @@ export default function ReportsPage() {
                       month: '2-digit',
                       day: '2-digit',
                     })}
-                  </span> */}
-                  <Link href={ROUTES.REPORT_EDIT(report.id)}>
-                    <span
-                      style={{
-                        fontWeight: '500',
-                        color: '#6b7280',
-                        textDecoration: 'underline',
-                        cursor: 'pointer',
-                      }}
-                    >
-                      {new Date(report.report_date).toLocaleDateString('ja-JP', {
-                        year: 'numeric',
-                        month: '2-digit',
-                        day: '2-digit',
-                      })}
-                    </span>
                   </span>
 
                   {/* 編集リンク */}
@@ -217,6 +194,7 @@ export default function ReportsPage() {
                       color: '#2563eb',
                       textDecoration: 'underline',
                       cursor: 'pointer',
+                      marginLeft: '1rem',
                     }}
                   >
                     編集


### PR DESCRIPTION
## 概要  
レポート一覧画面（`/reports`）において、日付の表示と編集リンクの位置・レイアウトを修正しました。  
コンフリクト解消後に一部のUI構造が重複していたため、正常な挙動と整った見た目に修正しています。

---

##  修正内容  
- 日付を「表示専用」として左側に配置  
- 「編集」リンクを右側に表示し、クリックで `/reports/[id]/edit` に遷移するよう修正  
- 不要なタグの重複とコメントアウトミスを解消  
- スタイル（背景・レイアウト）を既存のUIと統一  

---

## 修正ファイル  
- `Frontend/src/app/reports/page.tsx`

---

## 確認項目  
- 日付が正しく表示されること  
- 編集リンクをクリックすると対象レポートの編集画面に遷移すること  
- スタイル崩れ・エラーが発生しないこと  

---

## 背景  
developブランチとのコンフリクト解消時、旧修正と新修正の両方が残ったことで  
UI構造が一時的に崩れていたため、本修正で**最終的な統一と整合性の確保**を行いました。

---

## 備考  
この修正は**コンフリクト解消時に残っていた不整合（編集リンクと日付表示の重複）**を修正したものです。






